### PR TITLE
Add License, CoC, and a footer

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+# Code of Conduct
+
+We strive to be inclusive and value all people equally. Our values and
+guidelines can be found in our [Code of Conduct][coc].
+
+If you experience any behaviours or atmosphere that feels contrary to these
+values, please let us know at [hello@codereading.club][email]. We want everyone
+to feel safe, equal and welcome.
+
+[coc]: https://codereading.club/conduct
+[email]: mailto:hello@codereading.club

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License Copyright (c) 2022 Code Reading Club CIC
+
+Permission is hereby granted, free
+of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice
+(including the next paragraph) shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PDF Maker
 
 A tool to create PDFs from code on github.com for
-[Code Reading Clubs](https://code-reading.org/).
+[Code Reading Clubs](https://codereading.club/).
 
 ## How it's made
 

--- a/public/index.html
+++ b/public/index.html
@@ -7,13 +7,24 @@
     <title>PDF Maker</title>
     <style>
       body {
+        margin: 0;
+        padding: 5rem 0 2rem;
+        min-height: calc(100vh - 7rem);
         font-family: sans-serif;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
       }
 
       main {
         width: 90%;
         max-width: 40rem;
-        margin: 5rem auto 0;
+        flex-grow: 1;
+      }
+
+      footer {
+        width: 90%;
+        max-width: 40rem;
       }
 
       .error {
@@ -52,6 +63,14 @@
       <p class="info" id="info" hidden>Generating your PDF...</p>
       <p class="error" id="internal-error" hidden>Something went wrong</p>
     </main>
+    <footer>
+      <p>
+        This site is powered by <a href="https://netlify.com">Netlify</a>. Its
+        source is available on
+        <a href="https://github.com/CodeReadingClubs/pdf-maker">GitHub</a>. Pull
+        requests and issues always welcome!
+      </p>
+    </footer>
     <script>
       const form = document.getElementById('form')
       const input = document.getElementById('input')


### PR DESCRIPTION
A bunch of stuff we need to apply to [Netlify's open source plan](https://www.netlify.com/legal/open-source-policy):

- A license file (MIT)
- A code of conduct (which mainly refers to the one on our website)
- A footer with a link to Netlify (and a link to the repo)

Eerily similar to CodeReadingClubs/annotation-tool#20